### PR TITLE
Fix syntax highlighting in Github markdown using backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ this mailbox and executes the method within the thread.
 In a traditional actor model, the code in the camera Actor might look like
 this:
 
-```python hl_lines="6 7 8 16"
+```python
 import pygame, pygame.camera, time
 from guild.actor import *
 pygame.camera.init()
@@ -293,7 +293,7 @@ class Camera(Actor):
 If you did this, the display code would not need any changes. The start-up
 code that links things together though would now need to look like this:
 
-```python hl_lines="1 2 3"
+```python
 display = Display( (800,600) ).go()
 camera = Camera(display).go()
 # No pipeline line anymore
@@ -338,7 +338,7 @@ class FrameStore(Actor):
 
 This could then be used in a Guild pipeline system this way:
 
-```python hl_lines="2 4"
+```python
 camera = Camera().go()
 framestore = FrameStore().go()
 display = Display( (800,600) ).go()

--- a/README.md
+++ b/README.md
@@ -45,18 +45,20 @@ it differs (slightly) from traditional actors.
 
 Installation is pretty simple:
 
-    :::bash
-    $ git clone https://github.com/sparkslabs/guild
-    $ cd guild
-    $ sudo python setup.py install
+```bash
+$ git clone https://github.com/sparkslabs/guild
+$ cd guild
+$ sudo python setup.py install
+```
 
 If you'd prefer to build, install and use a debian package:
 
-    :::bash
-    $ git clone https://github.com/sparkslabs/guild
-    $ cd guild
-    $ make deb
-    $ sudo dpkg -i ../python-guild_1.0.0_all.deb
+```bash
+$ git clone https://github.com/sparkslabs/guild
+$ cd guild
+$ make deb
+$ sudo dpkg -i ../python-guild_1.0.0_all.deb
+```
 
 ## Example: viewing a webcam ##
 
@@ -67,42 +69,43 @@ the examples below can be reused as is.
 
 First of all the code, then a brief discussion.
 
-    :::python
-    import pygame, pygame.camera, time
-    from guild.actor import *
-    pygame.camera.init()
+```python
+import pygame, pygame.camera, time
+from guild.actor import *
+pygame.camera.init()
 
-    class Camera(Actor):
-        def gen_process(self):
-            camera = pygame.camera.Camera(pygame.camera.list_cameras()[0])
-            camera.start()
-            while True:
-                yield 1
-                frame = camera.get_image()
-                self.output(frame)
-                time.sleep(1.0/50)
+class Camera(Actor):
+    def gen_process(self):
+        camera = pygame.camera.Camera(pygame.camera.list_cameras()[0])
+        camera.start()
+        while True:
+            yield 1
+            frame = camera.get_image()
+            self.output(frame)
+            time.sleep(1.0/50)
 
-    class Display(Actor):
-        def __init__(self, size):
-            super(Display, self).__init__()
-            self.size = size
+class Display(Actor):
+    def __init__(self, size):
+        super(Display, self).__init__()
+        self.size = size
 
-        def process_start(self):
-            self.display = pygame.display.set_mode(self.size)
+    def process_start(self):
+        self.display = pygame.display.set_mode(self.size)
 
-        @actor_method
-        def show(self, frame):
-            self.display.blit(frame, (0,0))
-            pygame.display.flip()
+    @actor_method
+    def show(self, frame):
+        self.display.blit(frame, (0,0))
+        pygame.display.flip()
 
-        input = show
+    input = show
 
-    camera = Camera().go()
-    display = Display( (800,600) ).go()
-    pipeline(camera, display)
-    time.sleep(30)
-    stop(camera, display)
-    wait_for(camera, display)
+camera = Camera().go()
+display = Display( (800,600) ).go()
+pipeline(camera, display)
+time.sleep(30)
+stop(camera, display)
+wait_for(camera, display)
+```
 
 In this example, Camera is an active actor. That is it sits
 there, periodically grabbing frames from the webcam.  To do this, it uses a
@@ -134,73 +137,76 @@ actors had no specific shut down code, they shut down cleanly this way.
 This example follows two log files, and grep/output lines matching a given
 pattern.  In particular, it maps to this kind of command line:
 
-    :::bash
-    $ (tail -f x.log & tail -f y.log) | grep pants
+```bash
+$ (tail -f x.log & tail -f y.log) | grep pants
+```
 
 This example shows that there are still some areas that would benefit from
 additional syntactic sugar when it comes to wiring together pipelines.  In
 particular, this example should be writable together like this:
 
-    :::python
-    Pipeline( Parallel( Follow("x.log"), Follow("y.log"),
-              Grep("pants"),
-              Printer() ).run()
+```python
+Pipeline( Parallel( Follow("x.log"), Follow("y.log"),
+          Grep("pants"),
+          Printer() ).run()
+```
 
 However, I haven't implemented the necessary chassis yet (they will be).
 
 Once again, first the code, then a discussion.
 
-    :::python
-    from guild.actor import *
-    import re, sys, time
+```python
+from guild.actor import *
+import re, sys, time
 
-    class Follow(Actor):
-        def __init__(self, filename):
-            super(Follow, self).__init__()
-            self.filename = filename
-            self.f = None
+class Follow(Actor):
+    def __init__(self, filename):
+        super(Follow, self).__init__()
+        self.filename = filename
+        self.f = None
 
-        def gen_process(self):
-            self.f = f = file(self.filename)
-            f.seek(0,2)   # seek to end
-            while True:
-                yield 1
-                line = f.readline()
-                if not line: # no data, so wait
-                    time.sleep(0.1)
-                else:
-                    self.output(line)
-
-        def onStop(self):
-            if self.f:
-                self.f.close()
-
-    class Grep(Actor):
-        def __init__(self, pattern):
-            super(Grep, self).__init__()
-            self.regex = re.compile(pattern)
-
-        @actor_method
-        def input(self, line):
-            if self.regex.search(line):
+    def gen_process(self):
+        self.f = f = file(self.filename)
+        f.seek(0,2)   # seek to end
+        while True:
+            yield 1
+            line = f.readline()
+            if not line: # no data, so wait
+                time.sleep(0.1)
+            else:
                 self.output(line)
 
-    class Printer(Actor):
-        @actor_method
-        def input(self, line):
-            sys.stdout.write(line)
-            sys.stdout.flush()
+    def onStop(self):
+        if self.f:
+            self.f.close()
 
-    follow1 = Follow("x.log").go()
-    follow2 = Follow("y.log").go()
-    grep = Grep("pants").go()
-    printer = Printer().go()
+class Grep(Actor):
+    def __init__(self, pattern):
+        super(Grep, self).__init__()
+        self.regex = re.compile(pattern)
 
-    pipeline(follow1, grep, printer)
-    pipeline(follow2, grep)
-    wait_KeyboardInterrupt()
-    stop(follow1, follow2, grep, printer)
-    wait_for(follow1, follow2, grep, printer)
+    @actor_method
+    def input(self, line):
+        if self.regex.search(line):
+            self.output(line)
+
+class Printer(Actor):
+    @actor_method
+    def input(self, line):
+        sys.stdout.write(line)
+        sys.stdout.flush()
+
+follow1 = Follow("x.log").go()
+follow2 = Follow("y.log").go()
+grep = Grep("pants").go()
+printer = Printer().go()
+
+pipeline(follow1, grep, printer)
+pipeline(follow2, grep)
+wait_KeyboardInterrupt()
+stop(follow1, follow2, grep, printer)
+wait_for(follow1, follow2, grep, printer)
+```
 
 As you can see, like the bash example, we have two actors that tail/follow
 two different log files.  These both feed into the same 'grep' actor that
@@ -230,8 +236,9 @@ for display.  Each actor shows slightly different aspects of Guild's model.
 Guild will improve on in - specifying coordination more compactly.  For
 example, the Camera example could become:
 
-    :::python
-    Pipeline( Camera(),  Display( (800,600) ) ).run()
+```python
+Pipeline( Camera(),  Display( (800,600) ) ).run()
+```
 
 That's a work in progress however, adding with other chassis, and other
 useful parts of kamaelia.
@@ -259,24 +266,25 @@ this mailbox and executes the method within the thread.
 In a traditional actor model, the code in the camera Actor might look like
 this:
 
-    #!python hl_lines="6 7 8 16"
-    import pygame, pygame.camera, time
-    from guild.actor import *
-    pygame.camera.init()
+```python hl_lines="6 7 8 16"
+import pygame, pygame.camera, time
+from guild.actor import *
+pygame.camera.init()
 
-    class Camera(Actor):
-        def __init__(self, display):
-            super(Camera, self).__init__()
-            self.display = display
+class Camera(Actor):
+    def __init__(self, display):
+        super(Camera, self).__init__()
+        self.display = display
 
-        def gen_process(self):
-            camera = pygame.camera.Camera(pygame.camera.list_cameras()[0])
-            camera.start()
-            while True:
-                yield 1
-                frame = camera.get_image()
-                self.display.show(frame)
-                time.sleep(1.0/50)
+    def gen_process(self):
+        camera = pygame.camera.Camera(pygame.camera.list_cameras()[0])
+        camera.start()
+        while True:
+            yield 1
+            frame = camera.get_image()
+            self.display.show(frame)
+            time.sleep(1.0/50)
+```
 
 * **NB: This is perfectly valid in Guild.** If you don't want to use the
   idea of late bound methods or pipelining, then it can be used like any other
@@ -285,13 +293,14 @@ this:
 If you did this, the display code would not need any changes. The start-up
 code that links things together though would now need to look like this:
 
-    :::python hl_lines="1 2 3"
-    display = Display( (800,600) ).go()
-    camera = Camera(display).go()
-    # No pipeline line anymore
-    time.sleep(30)
-    stop(camera, display)
-    wait_for(camera, display)
+```python hl_lines="1 2 3"
+display = Display( (800,600) ).go()
+camera = Camera(display).go()
+# No pipeline line anymore
+time.sleep(30)
+stop(camera, display)
+wait_for(camera, display)
+```
 
 On the surface of things, this looks like a simplification, and on one level
 it is - we've removed one line from the program start-up code.  Our camera
@@ -302,68 +311,74 @@ I'd argue you've *lost* flexibility, but I'll leave why for later.
 For example, suppose we want to record the images to disk, we can do this by
 adding a third actor that can sit in the middle of others:
 
-    :::python
-    import time, os
-    class FrameStore(Actor):
-        def __init__(self, directory='Images', base='snap'):
-            super(FrameStore, self).__init__()
-            self.directory = directory
-            self.base = base
-            self.count = 0
+```python
+import time, os
+class FrameStore(Actor):
+    def __init__(self, directory='Images', base='snap'):
+        super(FrameStore, self).__init__()
+        self.directory = directory
+        self.base = base
+        self.count = 0
 
-        def process_start(self):
-            os.makedir(self.directory)
-            try:
-                os.makedirs("Images")
-             except OSError, e:
-                if e.errno != 17: raise
+    def process_start(self):
+        os.makedir(self.directory)
+        try:
+            os.makedirs("Images")
+         except OSError, e:
+            if e.errno != 17: raise
 
-        @actor_method
-        def input(self, frame):
-            self.count += 1
-            now = time.strftime("%Y%m%d-%H%M%S",time.localtime())
-            filename = "%s/%s-%s-%05d.jpg" % (self.directory, self.base, now, self.count)
-            pygame.image.save(frame, filename)
-            self.output(frame)
+    @actor_method
+    def input(self, frame):
+        self.count += 1
+        now = time.strftime("%Y%m%d-%H%M%S",time.localtime())
+        filename = "%s/%s-%s-%05d.jpg" % (self.directory, self.base, now, self.count)
+        pygame.image.save(frame, filename)
+        self.output(frame)
+```
 
 This could then be used in a Guild pipeline system this way:
 
-    :::python hl_lines="2 4"
-    camera = Camera().go()
-    framestore = FrameStore().go()
-    display = Display( (800,600) ).go()
-    pipeline(camera, framestore, display) 
-    time.sleep(30)
-    stop(camera, framestore, display) 
-    wait_for(camera, framestore, display)
+```python hl_lines="2 4"
+camera = Camera().go()
+framestore = FrameStore().go()
+display = Display( (800,600) ).go()
+pipeline(camera, framestore, display) 
+time.sleep(30)
+stop(camera, framestore, display) 
+wait_for(camera, framestore, display)
+```
 
 It's for this reason that Guild supports late bindable actor methods.
 
 What's happening here is that the definition of Actor includes this:
 
-    :::python
-    class Actor(object):
-        #...
-        @late_bind_safe
-        def output(self, *argv, **argd):
-            pass
+```python
+class Actor(object):
+    #...
+    @late_bind_safe
+    def output(self, *argv, **argd):
+        pass
+```
 
 That means every actor has available "output" as a late bound actor method.
 
 This pipeline called:
 
-    :::python
-    pipeline(camera, display)
+```python
+pipeline(camera, display)
+```
 
 Essentially does this:
 
-    :::python
-    camera.bind("output", display, "input")
+```python
+camera.bind("output", display, "input")
+```
 
 This transforms to a threadsafe version of this:
 
-    :::python
-    camera.output = display.input
+```python
+camera.output = display.input
+```
 
 As a result, it replaces the call camera.output with a call to display.input
 for us - meaning that it is as efficient to do camera.output as it is to do


### PR DESCRIPTION
Backticks seems to work better to get github syntax highlighting.
Unfortunately, had to remove the hl_lines="" property as well, to get it to work. Not sure how it could be added back again ...