### PR TITLE
Re-enable actors with just a main() generator

### DIFF
--- a/guild/actor.py
+++ b/guild/actor.py
@@ -353,6 +353,7 @@ class Actor(ActorMixin, _Thread):
             # NB next line looks at the code object, and checks a flag
             if inspect.isgeneratorfunction(gen):
                 g = gen()
+                self.killflag = False  # Or else an empty process_method can cause shutdown
             else:
                 function_name = gen.__self__.__class__.__name__ +"."+gen.__name__
                 source_ref = "(%s, line: %d)" % (gen.__func__.__code__.co_filename, gen.__func__.__code__.co_firstlineno)


### PR DESCRIPTION
This got bust, which is annoying. It's actually a logic error overall, and ideally the fix would be more than this fix, but this fix will work for the bulk of situations. What would be better is to seperate out the 3 criterion:
* Is the process_method running
* Is there a generator and is it running
* Have we been asked to shutdown.

At the moment these 3 are conflated which is a problem, but this change fixes this for the bulk of situations. Would be nice to rewrite this part of the codebase.